### PR TITLE
Added more subtype strings from temperhum due to variations

### DIFF
--- a/libtempered/temper_type.c
+++ b/libtempered/temper_type.c
@@ -39,6 +39,8 @@ struct temper_type known_temper_types[]={
 				"TEMPerHumV1.0rHu",
 				"TEMPerHumM12V1.0",
 				"TEMPerHumM12V1.2",
+                                "TEMPerHumM12V1",
+                                "TEMPermM12V1",
 				NULL
 			}
 		},


### PR DESCRIPTION
I am not sure why but sometimes I get this:

```
pi@raspberrypi ~/TEMPered $ sudo ./utils/tempered 
/dev/hidraw1: Could not open device: Unknown device subtype string: TEMPerHumM12V1
pi@raspberrypi ~/TEMPered $ sudo ./utils/tempered 
/dev/hidraw1: Could not open device: Unknown device subtype string: TEMPerHumM12V1
pi@raspberrypi ~/TEMPered $ sudo ./utils/tempered 
/dev/hidraw1: Could not open device: Unknown device subtype string: TEMPerHumM12V1
pi@raspberrypi ~/TEMPered $ sudo ./utils/tempered 
/dev/hidraw1: Could not open device: Unknown device subtype string: TEMPermM12V1
pi@raspberrypi ~/TEMPered $ sudo ./utils/tempered 
/dev/hidraw1: Could not open device: Unknown device subtype string: TEMPermM12V1
pi@raspberrypi ~/TEMPered $ sudo ./utils/tempered 
/dev/hidraw1 0: temperature 34.89 °C, relative humidity 34.4%, dew point 16.9 °C
```

It'll intermittently work or not work.  
